### PR TITLE
Smp cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ setup.cfg
 .coverage
 .gdb_history
 
-.idea/sonarlint/
+.idea
+/mfscripts/smp/pbn/

--- a/mfscripts/smp/README.md
+++ b/mfscripts/smp/README.md
@@ -41,13 +41,14 @@ create and process a whole new set...
 ## Structure of the files here
 
 - [smp_definitions.py]() is where all the shapes are,
-  and all the tests (is it a 1C opener?), and any other utility functions.
+  and all the tests (is it a 1C opener?).
+- [generate_hands.py]() is where all the "make a bunch of hands" functions are.
 - The individual files (like [smp_1d.py]()) have a pretty simple structure:
     - Put "tweaks" at the top so they can be quickly massaged.
     - If there's any custom test, that goes next.
     - Deal accept function (which will use all the above).
     - if there's a condition that is suitable for a predeal (especially a SmartStack),
-      put it next. Remember this is a dict: {"<seat>": <condition>}
+      put it next. Remember this is a dict: {"\<seat\>": \<condition\>}
     - then make a file, and:
 
 ```python
@@ -57,14 +58,36 @@ with Path(file).open(encoding="utf-8", mode="w") as f:
         accept,  # the accept function
         predeal=predeal,  # if you have one, else None
         num_hands=int,  # default 100
-        alternate_after=int,  # if < num_hands, rotates 180 degrees every N.
+        alternate_after=int,  # if < num_hands, rotates 180 degrees every N hands.
     )
 ```
 
-- generate_and_print_hands is designed specifically for bidding tables, so
+- `generate_and_print_hands` is designed specifically for bidding tables, so
   South is dealer every hand.
-- If alternate_after, North gets to be dealer half the time.
-    - When he is, his hands
-      will match the same criteria as *South's hand* when he's dealer - and vice versa.
+- If `alternate_after`, North gets to be dealer half the time.
+    - When he is, his hands will match the same criteria as 
+      *South's hand* when he's dealer - and vice versa.
     - This simulates the effect of switching seats so that
-      "I get to open for a bit and you answer."
+      "I get to open for a bit, and you answer."
+
+- To combine several accept criteria (so that you can practise different things 
+  while not knowing which one comes up this time), you can use the Pass structure
+  and the combine_and_print_hands function:
+
+```python
+
+    passes = Pass(
+        (<accept_function_1>, <predeal_1>_or_None),
+        (<accept_function_2>, <predeal_2>_or_None),
+        ...
+    )
+
+    outputs = generate_pbn_passes(passes)
+    with Path(file).open(encoding="utf-8", mode="w") as f:
+        combine_and_print_hands(
+            f, 
+            outputs, 
+            randomize=bool,  # if False, print in order.  if True, shuffle before printing
+            alternate_after=int  # if < num_hands, rotates 180 degrees every N hands.
+        )
+```

--- a/mfscripts/smp/generate_hands.py
+++ b/mfscripts/smp/generate_hands.py
@@ -63,9 +63,11 @@ def generate_and_print_hands(
 
 
 def generate_pbn_hands(criteria: Pass) -> list[str]:
-    """Generate and deal hands with constraints, return each as just the deal line in PBN.
+    """Generate and deal hands with constraints, return each as just the deal in PBN.
 
-    This is useful for later manipulation as "dealer" is always South, and nothing else is needed.
+    This can be manipulated later as "dealer" is always South so the constraints
+    always apply correctly; it is easy, say, to rotate the hand so North is dealer,
+    but "opener" will always have opener's constraints, and responder theirs.
     """
 
     Deal.set_str_style("pbn")

--- a/mfscripts/smp/generate_hands.py
+++ b/mfscripts/smp/generate_hands.py
@@ -1,0 +1,140 @@
+"""functions to print hands"""
+
+import itertools
+import random
+from dataclasses import dataclass
+from typing import Callable, Iterable, Optional, TextIO
+
+from redeal import Deal, SmartStack
+
+VULNERABILITY = ("None", "NS", "EW", "Both")
+
+
+@dataclass
+class Pass:
+    """One of potentially multiple "Passes" of generated hands to amalgamate.
+
+    If we want to practise hands, but not "know" what hand partner has, we can
+    generate "10 of these, 15 of these, 5 of these" and then combine them into
+    one pbn file.
+
+    Consists of an accept function, an optional `SmartStack` used to predeal, and
+    the number of hands that meet the criteria to return.
+
+    Needs a better name, given the ambiguity with a bridge Pass call!
+    """
+
+    accept_function: Callable[[Deal], bool]
+    predeal: Optional[dict[str, SmartStack]]
+    num_hands: int = 10
+
+
+def generate_and_print_pass(
+    output: TextIO,
+    criteria: Pass,
+    alternate_after: int = 5,
+) -> None:
+    """Generate and deal hands with a single constraint.  Convenience function.
+
+    Reverses the PBN (set dealer N and rotate the hand 180 degrees)
+    every `alternate_after` hands.  To not do this, set alternate_after >= num_hands.
+
+    """
+    deals = generate_pbn_hands(criteria)
+    print_pbn_hands(output, deals, alternate_after)
+
+
+def generate_and_print_hands(
+    output: TextIO,
+    accept_function: Callable,
+    predeal: Optional[dir] = None,
+    num_hands: int = 20,
+    alternate_after: int = 5,
+) -> None:
+    """Generate and deal hands with constraint.
+
+    Old-style input, not using `Pass` dataclass for criteria.
+    """
+    generate_and_print_pass(
+        output,
+        Pass(accept_function, predeal, num_hands),
+        alternate_after,
+    )
+
+
+def generate_pbn_hands(criteria: Pass) -> list[str]:
+    """Generate and deal hands with constraints, return each as just the deal line in PBN.
+
+    This is useful for later manipulation as "dealer" is always South, and nothing else is needed.
+    """
+
+    Deal.set_str_style("pbn")
+    dealer = Deal.prepare(criteria.predeal)
+    output = []
+
+    for _ in range(criteria.num_hands):
+        deal = str(dealer(criteria.accept_function))
+        output.append(deal)
+
+    return output
+
+
+def generate_pbn_passes(
+    criteria: Iterable[Pass],
+) -> list[list[str]]:
+    """Generate and deal hands with multiple constraints, output as PBN deals.
+
+    Convenience function for calling `generate_pbn_hands` repeatedly with different
+    accept criteria and predeal (a "pass") and returning all results in a format i
+    suitable for combining either linearly or randomly with `combine_and_print_hands`.
+    """
+
+    output = []
+    for criterion in criteria:
+        output.append(generate_pbn_hands(criterion))
+    return output
+
+
+def print_pbn_hands(
+    output: TextIO,
+    deals: list[str],
+    alternate_after: int = 5,
+) -> None:
+    """Print the hands in full pbn format."""
+
+    for i, deal in enumerate(deals):
+        dlr = "S"
+        if i // alternate_after % 2:
+            deal = deal.replace("N", "S", 1)
+            dlr = "N"
+        output.writelines(
+            [
+                f'\n[Board "{i + 1}"]',
+                f'\n[Dealer "{dlr}"]',
+                f'\n[Vulnerable "{random.choice(VULNERABILITY)}"]\n',
+                deal,
+                "\n",
+            ]
+        )
+
+
+def combine_and_print_hands(
+    output: TextIO,
+    deal_sets: list[list[str]],
+    randomize: bool = True,
+    alternate_after: int = 5,
+) -> None:
+    """Combine multiple sets of deals created with generate_pbn_hands and print them.
+
+    This interleaves the hands from each set.
+    If randomize is True, then randomize after interleave.
+    """
+
+    combined_deals = [
+        x
+        for x in itertools.chain.from_iterable(itertools.zip_longest(*deal_sets))
+        if x is not None
+    ]
+    if randomize:
+        random.shuffle(combined_deals)
+    print_pbn_hands(output, combined_deals, alternate_after)

--- a/mfscripts/smp/smp_1c_1d.py
+++ b/mfscripts/smp/smp_1c_1d.py
@@ -3,18 +3,20 @@
 import sys
 from pathlib import Path
 
-from redeal import Deal, Hand, hcp
-from smp_definitions import (
-    balanced_no_5cM,
-    four_card_major,
-    generate_and_print_hands,
-    one_club_opener,
-    one_diamond_response_sc,
-)
+from redeal import Deal, Hand, balanced, hcp
+
+from generate_hands import generate_and_print_hands
+from smp_definitions import four_card_major, one_club_opener
 
 # TWEAK HERE
-REBID_1M = False  # if the hands should be 1C-1D; 1M, or 1C-1D; any
+REBID_1M = True  # if the hands should be 1C-1D; 1M, or 1C-1D; any
 DEBUG = True
+
+
+def strong_one_diamond_response(hand: Hand) -> bool:
+    """5-7 HCP."""
+
+    return 5 <= hcp(hand) <= 7
 
 
 def one_major_rebid(hand: Hand) -> bool:
@@ -26,12 +28,13 @@ def one_major_rebid(hand: Hand) -> bool:
     """
     gf = hcp(hand) >= 22
 
-    return not gf and not balanced_no_5cM(hand) and four_card_major(hand)
+    return not gf and not balanced(hand) and four_card_major(hand)
 
 
 def accept(deal: Deal) -> bool:
     """Accept if 1C-1D (; 1M)."""
-    if not one_club_opener(deal.south) or not one_diamond_response_sc(deal.north):
+    # if not one_club_opener(deal.south) or not one_diamond_response_sc(deal.north):
+    if not one_club_opener(deal.south) or not strong_one_diamond_response(deal.north):
         return False
     if not REBID_1M:
         return True

--- a/mfscripts/smp/smp_1d.py
+++ b/mfscripts/smp/smp_1d.py
@@ -4,10 +4,11 @@ import sys
 from pathlib import Path
 
 from redeal import Deal, Hand, balanced, hcp
+
+from generate_hands import generate_and_print_hands
 from smp_definitions import (
     five_card_major,
     four_card_major,
-    generate_and_print_hands,
     minor_lengths,
     one_diamond_opener,
 )
@@ -60,6 +61,7 @@ def accept(deal: Deal) -> bool:
     return False
 
 
-F = f"1D{"-2m" if RESP_2m else ""}.pbn"
-with Path(Path.cwd() / F).open(encoding="utf=8", mode="w") as f:
-    generate_and_print_hands(f, accept)
+if __name__ == "__main__":
+    F = f"1D{"-2m" if RESP_2m else ""}.pbn"
+    with Path(Path.cwd() / "pbn" / F).open(encoding="utf=8", mode="w") as f:
+        generate_and_print_hands(f, accept)

--- a/mfscripts/smp/smp_2c.py
+++ b/mfscripts/smp/smp_2c.py
@@ -4,7 +4,9 @@ import sys
 from pathlib import Path
 
 from redeal import Deal, Hand, SmartStack, hcp
-from smp_definitions import generate_and_print_hands, two_clubs_shape
+
+from generate_hands import generate_and_print_hands
+from smp_definitions import two_clubs_shape
 
 # TWEAK HERE
 # Set this true if the hands should be 2C-2D, False if any response allowed

--- a/mfscripts/smp/smp_2d.py
+++ b/mfscripts/smp/smp_2d.py
@@ -4,7 +4,9 @@ import sys
 from pathlib import Path
 
 from redeal import Deal, Hand, Holding, Rank, Shape, SmartStack, hcp
-from smp_definitions import generate_and_print_hands, two_diamond_shape
+
+from generate_hands import generate_and_print_hands
+from smp_definitions import two_diamond_shape
 
 # TWEAK HERE
 # Set this true if the hands should be 2D-2NT, False if any response allowed

--- a/mfscripts/smp/smp_all_weird.py
+++ b/mfscripts/smp/smp_all_weird.py
@@ -1,65 +1,72 @@
 """Generate all "weird" hands for SMP."""
 
-from collections import defaultdict
 from pathlib import Path
-from pprint import pprint
 
+from redeal import Deal
+
+from generate_hands import Pass, combine_and_print_hands, generate_pbn_passes
 from smp_1d import two_m_response
 from smp_definitions import (
-    generate_and_print_hands,
+    ns_hcp,
     one_club_opener,
     one_diamond_opener,
     one_diamond_response_sc,
+    strong_response_sc,
     two_clubs_opener,
     two_diamonds_opener,
 )
 
-from redeal import Deal, hcp
-
 # TWEAK HERE
-ALLOW_STRONG_NON_WEIRD = True  # allow slammish hands not in the weird categories
-REQUIRE_STRONG_WEIRD = False  # only accept slammish hands in the weird categories
+ALLOW_STRONG = True  # allow slammish hands not in the weird categories
+REQUIRE_STRONG = False  # only accept slammish hands in the weird categories
 MIN_HCP_STRONG = 29
 DEBUG = True
 
 
-HAND_TYPE = defaultdict(int)
-
-
 def slammish(deal: Deal) -> bool:
     """Is slammish if HCP(NS) >= MIN_HCP_STRONG."""
-    return hcp(deal.north) + hcp(deal.south) >= MIN_HCP_STRONG
+    return ns_hcp(deal) >= MIN_HCP_STRONG
 
 
-def accept(deal: Deal) -> bool:
-    """For the various cases, accept if they're weird (and/or strong)"""
-    accepted = False  # assume wrong
-    HAND_TYPE["n_hands"] += 1
-
-    n, s = deal.north, deal.south
-    if one_club_opener(s) and (one_diamond_response_sc(n) or hcp(n) > 12):
-        accepted = True
-        HAND_TYPE["1c1d"] += 1
-    elif one_diamond_opener(s) and two_m_response(n):
-        accepted = True
-        HAND_TYPE["1d2m"] += 1
-    elif two_clubs_opener(s) or two_diamonds_opener(s):
-        accepted = True
-        HAND_TYPE["2m"] += 1
-
-    if ALLOW_STRONG_NON_WEIRD:
-        if not accepted and slammish(deal):
-            accepted = True
-            HAND_TYPE["slam"] += 1
-        return accepted
-    elif REQUIRE_STRONG_WEIRD:
-        return accepted and slammish(deal)
-    else:
-        return accepted
+def slammish_if_required(deal: Deal) -> bool:
+    """if REQUIRE_STRONG, only true if slammish.  Always True otherwise."""
+    return not REQUIRE_STRONG or slammish(deal)
 
 
+def accept_1c_1d(deal: Deal) -> bool:
+    """1C-1D, or 1C-12+"""
+    return (
+        one_club_opener(deal.south)
+        and (one_diamond_response_sc(deal.north) or strong_response_sc(deal.north))
+        and slammish_if_required(deal)
+    )
+
+
+def accept_1d_2m(deal: Deal) -> bool:
+    """1D-2m response hands."""
+    return (
+        one_diamond_opener(deal.south)
+        and two_m_response(deal.north)
+        and slammish_if_required(deal)
+    )
+
+
+def accept_2m(deal: Deal) -> bool:
+    """2C or 2D openers"""
+    return (
+        two_clubs_opener(deal.south) or two_diamonds_opener(deal.south)
+    ) and slammish_if_required(deal)
+
+
+criteria = [
+    Pass(accept_1c_1d, None),
+    Pass(accept_1d_2m, None),
+    Pass(accept_2m, None),
+]
+if ALLOW_STRONG:
+    criteria.append(Pass(slammish, None))
+
+outputs = generate_pbn_passes(criteria)
 F = "SMP_weird.pbn"
-with (Path.cwd() / F).open(encoding="utf=8", mode="w") as f:
-    generate_and_print_hands(f, accept, alternate_after=5, num_hands=40)
-if DEBUG:
-    pprint(HAND_TYPE)
+with (Path.cwd() / "pbn" / F).open(encoding="utf=8", mode="w") as f:
+    combine_and_print_hands(f, outputs, randomize=True, alternate_after=5)

--- a/mfscripts/smp/smp_definitions.py
+++ b/mfscripts/smp/smp_definitions.py
@@ -1,31 +1,29 @@
 """utility functions for SMP bidding practise."""
 
-import itertools
-import random
-from typing import Callable, Optional, TextIO
+from redeal import Deal, Hand, Shape, balanced
 
-from redeal import Deal, Hand, Shape, balanced, hcp
-
-# tester functions.  All take a hand and return True-if-match.
+# useful shapes
 balanced_no_5cM = balanced - Shape("5xxx") - Shape("x5xx")
+marmic = Shape("(4441)")
 two_clubs_shape = Shape.from_cond(lambda s, h, d, c: c >= 6 and c > max([s, h, d]))
 two_diamond_shape = Shape("3415") + Shape("4315") + Shape("4405") + Shape("4414")
 
 
-def _non_1c_strength(hand: Hand, nv: bool = False) -> bool:
+# tester functions.  All take a hand and return True-if-match.
+def _opener_not_1c(hand: Hand, nv: bool = False) -> bool:
     """True if an "11-15" opener.  NV, can be 10"""
     min_opener = 10 if nv else 11
-    return hcp(hand) in range(min_opener, 16)
+    return hand.hcp in range(min_opener, 16)
 
 
 def one_club_opener(hand: Hand) -> bool:
     """True if 16+ unBAL or 16-19 or 22+ BAL"""
-    return hcp(hand) > 16 and not one_nt_opener(hand) and not two_nt_opener(hand)
+    return hand.hcp > 16 and not one_nt_opener(hand) and not two_nt_opener(hand)
 
 
 def one_diamond_opener(hand: Hand) -> bool:
     """True if 1D opener.  Special catchall: "not anything else"."""
-    return _non_1c_strength(hand) and not (
+    return _opener_not_1c(hand) and not (
         one_nt_opener(hand)
         or one_heart_opener(hand)
         or one_spade_opener(hand)
@@ -38,7 +36,7 @@ def one_heart_opener(hand: Hand) -> bool:
     """True if 1H opener.  Will bid 1S with equal length, 1D or 2C if longer."""
     hearts = len(hand.hearts)
     return (
-        _non_1c_strength(hand)
+        _opener_not_1c(hand)
         and hearts >= 5
         and hearts > len(hand.spades)
         and hearts >= max(minor_lengths(hand))
@@ -48,43 +46,43 @@ def one_heart_opener(hand: Hand) -> bool:
 def one_spade_opener(hand: Hand) -> bool:
     """True if 1S opener.  spades at least tied for longest."""
     spades = len(hand.spades)
-    return _non_1c_strength(hand) and spades >= 5 and spades == hand.l1
+    return _opener_not_1c(hand) and spades >= 5 and spades == hand.l1
 
 
 def one_nt_opener(hand: Hand) -> bool:
-    """True if balanced 14-16.  We do not open 5cM 1NT."""
-    return hcp(hand) in range(14, 17) and balanced(hand)
+    """True if balanced 14-16.  We 100% open 5cM 1NT."""
+    return hand.hcp in range(14, 17) and balanced(hand)
 
 
 def two_clubs_opener(hand: Hand) -> bool:
     """True if 2C opener.  6 clubs, not 6-6."""
-    return _non_1c_strength(hand) and two_clubs_shape(hand)
+    return _opener_not_1c(hand) and two_clubs_shape(hand)
 
 
 def two_diamonds_opener(hand: Hand) -> bool:
     """True if 2D opener.  4415 minus a card."""
-    return _non_1c_strength(hand) and two_diamond_shape(hand)
+    return _opener_not_1c(hand) and two_diamond_shape(hand)
 
 
 def two_nt_opener(hand: Hand) -> bool:
     """True if 2NT opener.  20-21 balanced (could be 5cM)"""
-    return hcp(hand) in range(20, 22) and balanced(hand)
+    return hand.hcp in range(20, 22) and balanced(hand)
 
 
 # One club responses
 def one_diamond_response_sc(hand: Hand) -> bool:
     """True if 0-7 HCP (1D response to 1C).  For ease of reading."""
-    return hcp(hand) <= 7
+    return hand.hcp <= 7
 
 
 def one_heart_response_sc(hand: Hand) -> bool:
     """True if 8-11 HCP (1H response to 1C). For ease of reading."""
-    return hcp(hand) in range(8, 12)
+    return hand.hcp in range(8, 12)
 
 
 def strong_response_sc(hand: Hand) -> bool:
     """True if 12+ HCP (1S+ response to 1C).  For ease of reading."""
-    return hcp(hand) >= 12
+    return hand.hcp >= 12
 
 
 # convenience functions.
@@ -117,90 +115,4 @@ def five_card_major(hand: Hand, plus: bool = True) -> bool:
 
 def ns_hcp(deal: Deal) -> int:
     """Return NS HCP total"""
-    return hcp(deal.north) + hcp(deal.south)
-
-
-# functions to print hands
-def generate_and_print_hands(
-    output: TextIO,
-    accept_function: Callable,
-    predeal: Optional[dir] = None,
-    num_hands: int = 20,
-    alternate_after: int = 5,
-) -> None:
-    """Generate and deal hands with constraints.  Convenience function.
-
-    reverse the PBN (set dealer N and rotate the hand 180 degrees)
-    every alternate_after hands.  To not do this, set alternate_after >= num_hands.
-
-    """
-    deals = generate_pbn_hands(accept_function, predeal, num_hands)
-    print_pbn_hands(output, deals, alternate_after)
-
-
-def generate_pbn_hands(
-    accept_function: Callable,
-    predeal: Optional[dir] = None,
-    num_hands: int = 20,
-) -> list[str]:
-    """Generate and deal hands with constraints, print as just the deal line in PBN.
-
-    This is useful for later manipulation as "dealer" is always South, and nothing else is needed.
-    """
-
-    Deal.set_str_style("pbn")
-    dealer = Deal.prepare(predeal)
-    output = []
-
-    for _ in range(num_hands):
-        deal = str(dealer(accept_function))
-        output.append(deal)
-
-    return output
-
-
-def print_pbn_hands(
-    output: TextIO,
-    deals: list[str],
-    alternate_after: int = 5,
-) -> None:
-    """Print the hands in full pbn format."""
-
-    vulnerabilities = ["None", "NS", "EW", "Both"]
-
-    for i, deal in enumerate(deals):
-        dlr = "S"
-        if i // alternate_after % 2:
-            deal = deal.replace("N", "S", 1)
-            dlr = "N"
-        output.writelines(
-            [
-                f'\n[Board "{i + 1}"]',
-                f'\n[Dealer "{dlr}"]',
-                f'\n[Vulnerable "{random.choice(vulnerabilities)}"]\n',
-                deal,
-                "\n",
-            ]
-        )
-
-
-def combine_and_print_hands(
-    output: TextIO,
-    deal_sets: list[list[str]],
-    randomize: bool = True,
-    alternate_after: int = 5,
-) -> None:
-    """Combine multiple sets of deals created with generate_pbn_hands and print them.
-
-    This interleaves the hands from each set.
-    If randomize is True, then randomize after interleave.
-    """
-
-    combined_deals = [
-        x
-        for x in itertools.chain.from_iterable(itertools.zip_longest(*deal_sets))
-        if x is not None
-    ]
-    if randomize:
-        random.shuffle(combined_deals)
-    print_pbn_hands(output, combined_deals, alternate_after)
+    return deal.north.hcp + deal.south.hcp

--- a/mfscripts/smp/smp_marmic.py
+++ b/mfscripts/smp/smp_marmic.py
@@ -1,23 +1,23 @@
 """SMP: Strong hands and 4441s"""
 
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Optional
 
-from mfscripts.smp.smp_definitions import (
-    combine_and_print_hands,
-    generate_pbn_hands,
+from redeal import Deal, SmartStack, hcp
+
+from generate_hands import Pass, combine_and_print_hands, generate_pbn_passes
+from smp_definitions import (
+    marmic,
     ns_hcp,
     one_club_opener,
+    one_diamond_response_sc,
+    strong_response_sc,
     two_diamond_shape,
     two_diamonds_opener,
 )
-from redeal import Deal, Shape, SmartStack, hcp
 
+# TWEAK HERE
 DEBUG = False
-marmic = Shape("(4441)")  # any marmic hand
-OUTPUTS = []
-MIN_HCP_STRONG = 29
+MIN_HCP_STRONG = 23
 
 
 def two_diamond_accept(deal: Deal) -> bool:
@@ -31,7 +31,11 @@ def two_diamond_accept(deal: Deal) -> bool:
 
 def one_club_marmic(deal: Deal) -> bool:
     """Accept if 1C -> GF and marmic"""
-    if one_club_opener(deal.south) and marmic(deal.south) and hcp(deal.north) > 7:
+    if (
+        one_club_opener(deal.south)
+        and marmic(deal.south)
+        and not one_diamond_response_sc(deal.north)
+    ):
         if DEBUG:
             print(deal)
         return True
@@ -40,7 +44,7 @@ def one_club_marmic(deal: Deal) -> bool:
 
 def one_club_strong_resp(deal: Deal) -> bool:
     """Accept if 1C and resp >= 12"""
-    if one_club_opener(deal.south) and hcp(deal.north) > 11:
+    if one_club_opener(deal.south) and strong_response_sc(deal.north):
         if DEBUG:
             print(deal)
         return True
@@ -48,17 +52,12 @@ def one_club_strong_resp(deal: Deal) -> bool:
 
 
 def one_club_strong_marmic(deal: Deal) -> bool:
+    """Accept if 1C and responder is 4441 >= 12"""
     if one_club_strong_resp(deal) and marmic(deal.north):
         if DEBUG:
             print(deal)
         return True
     return False
-
-
-@dataclass
-class Pass:
-    accept_function: Callable[[Deal], bool]
-    predeal: Optional[dict[str, SmartStack]]
 
 
 passes = (
@@ -68,10 +67,8 @@ passes = (
     Pass(one_club_strong_marmic, {"N": SmartStack(marmic, hcp, range(12, 25))}),
 )
 
-
-for pass_ in passes:
-    OUTPUTS.append(generate_pbn_hands(pass_.accept_function, pass_.predeal, 10))
+outputs = generate_pbn_passes(passes)
 
 F = "marmic.pbn"
-with (Path.cwd() / F).open(encoding="utf-8", mode="w") as f:
-    combine_and_print_hands(f, OUTPUTS, randomize=True, alternate_after=5)
+with (Path.cwd() / "pbn" / F).open(encoding="utf-8", mode="w") as f:
+    combine_and_print_hands(f, outputs, randomize=True, alternate_after=5)

--- a/mfscripts/smp/smp_oct_collector.py
+++ b/mfscripts/smp/smp_oct_collector.py
@@ -4,11 +4,7 @@ from pathlib import Path
 
 from redeal import Deal, Hand, SmartStack, hcp
 
-from generate_hands import (
-    Pass,
-    combine_and_print_hands,
-    generate_pbn_passes,
-)
+from generate_hands import Pass, combine_and_print_hands, generate_pbn_passes
 from smp_1d import two_m_response
 from smp_definitions import (
     ns_hcp,

--- a/mfscripts/smp/smp_oct_collector.py
+++ b/mfscripts/smp/smp_oct_collector.py
@@ -1,0 +1,64 @@
+"""SMP: October weird tests"""
+
+from pathlib import Path
+
+from redeal import Deal, Hand, SmartStack, hcp
+
+from generate_hands import (
+    Pass,
+    combine_and_print_hands,
+    generate_pbn_passes,
+)
+from smp_1d import two_m_response
+from smp_definitions import (
+    ns_hcp,
+    one_diamond_opener,
+    one_heart_opener,
+    one_spade_opener,
+    two_clubs_opener,
+    two_diamond_shape,
+    two_diamonds_opener,
+)
+
+DEBUG = False
+MIN_HCP_STRONG = 23
+
+
+def two_club_accept(deal: Deal) -> bool:
+    return two_clubs_opener(deal.south) and ns_hcp(deal) > 20
+
+
+def two_diamond_accept(deal: Deal) -> bool:
+    return two_diamonds_opener(deal.south) and ns_hcp(deal) > 20
+
+
+def one_major_opener_values(deal: Deal) -> bool:
+    return (
+        one_spade_opener(deal.south) or one_heart_opener(deal.south)
+    ) and 18 <= ns_hcp(deal) <= 28
+
+
+def reverse_flannery(hand: Hand, min_hcp: int = 0, max_hcp: int = 40) -> bool:
+    """Reverse Flannery: 54xx. We play 1D-2M as RF < GF."""
+    return hand.spades == 5 and hand.hearts == 4 and min_hcp <= hand.hcp <= max_hcp
+
+
+def one_diamond_weird(deal: Deal) -> bool:
+    return one_diamond_opener(deal.south) and (
+        two_m_response(deal.north) or reverse_flannery(deal.north, min_hcp=5)
+    )
+
+
+passes = (
+    Pass(
+        two_diamond_accept, {"S": SmartStack(two_diamond_shape, hcp, range(11, 16))}, 6
+    ),
+    Pass(one_major_opener_values, None, 12),
+    Pass(one_diamond_weird, None, 6),
+)
+
+
+outputs = generate_pbn_passes(passes)
+F = "collector.pbn"
+with (Path.cwd() / "pbn" / F).open(encoding="utf-8", mode="w") as f:
+    combine_and_print_hands(f, outputs, randomize=True, alternate_after=5)


### PR DESCRIPTION
Added `Pass` structure to allow multiple types of hands (and different, specific numbers of each)
to be amalgamated into one pbn file, to make it easy to practise situations without "knowing" which one it is.

Moved all the "generate hands" functions into their own file, as they aren't really "definitions".

Moved a bunch of useful definitions out of "runner" files into `smp_definitions.py`.

Fixed the runner files to use the new functions in the new places, and to put the output files in a "pbn" subdirectory so it
can be .gitignored (and lint-ignored).